### PR TITLE
feature: EC2 중단 시간대 기상 데이터 백필 파이프라인 구현

### DIFF
--- a/dags/weather_data_backfill_night.py
+++ b/dags/weather_data_backfill_night.py
@@ -1,0 +1,165 @@
+import json
+import logging
+from airflow.models.variable import Variable
+from airflow.decorators import dag, task
+from airflow.providers.amazon.aws.operators.s3 import S3Hook
+from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
+from airflow.providers.amazon.aws.operators.glue import GlueJobOperator
+from datetime import timedelta
+import pendulum
+
+
+logger = logging.getLogger(__name__)
+BUCKET_NAME = Variable.get("BUCKET_NAME")
+DBT_PROJECT_DIR = Variable.get("DBT_PROJECT_DIR")
+DBT_PROFILES_DIR = Variable.get("DBT_PROFILES_DIR")
+
+default_args = {
+    "onwer": "dongyeong",
+    "retries": 3,
+    "retry_delay": timedelta(seconds=10),
+}
+
+
+@dag(
+    dag_id="weather_data_backfill_night",
+    schedule="0 9 * * *",
+    start_date=pendulum.datetime(2025, 7, 1, tz="Asia/Seoul"),
+    catchup=False,
+    tags=["weather", "glue", "backfill"],
+    default_args=default_args,
+    doc_md="""
+    # 기상데이터 Backfill용 DAG
+    이 DAG는 매일 오전 9시에 실행되어, 전날 밤 9시부터 오전 9시까지의 12시간 동안 누락되었을 수 있는 기상 데이터를 백필합니다.
+
+    ### 주요 작업
+    1. **Glue Job**: S3의 원시 JSON 데이터를 Parquet으로 변환하여 저장합니다.
+    2. **Redshift COPY**: Manifest 파일을 사용하여 변환된 데이터를 Redshift의 source.source_weather 테이블에 적재합니다.
+    3. **dbt run**: fact_weather 모델을 실행하여 팩트 테이블을 증분적재 합니다.
+
+    ### 스케줄
+    - 매일 오전 9시 (KST)
+    - 전날 밤 9시 ~ 당일 오전 9시 데이터 처리
+    """,
+)
+def weather_data_backfill_night():
+    run_glue_job = GlueJobOperator(
+        task_id="run_glue_job",
+        aws_conn_id="aws_default",
+        region_name="ap-northeast-2",
+        iam_role_name="de6-team1-glue-role",
+        job_name="de6-team1-glue-weather-backfill-night",
+        s3_bucket=BUCKET_NAME,
+        script_location=f"s3://{BUCKET_NAME}/glue/jobs/weather_backfill_night_etl.py",
+        script_args={
+            "--JOB_NAME": "weather_data_backfill_night",
+            "--logical_date": "{{ logical_date }}",
+        },
+        create_job_kwargs={
+            "GlueVersion": "5.0",
+            "WorkerType": "G.1X",
+            "NumberOfWorkers": 10,
+        },
+    )
+
+    @task
+    def load_to_redshift(**context):
+        utc_time = context["logical_date"]
+        kst_time = utc_time.in_timezone("Asia/Seoul")
+        start_dt = kst_time - timedelta(hours=12)
+        end_dt = kst_time
+
+        s3_hook = S3Hook("aws_default")
+        manifest_entries = {"entries": []}
+
+        # Build manifest entries from parquet files by hourly partitions
+        current_dt = start_dt
+        while current_dt < end_dt:
+            prefix = (
+                f"processed-data/weather/night-backfill/"
+                f"year={current_dt.year}/"
+                f"month={current_dt.month}/"
+                f"day={current_dt.day}/"
+                f"hour={current_dt.hour}/"
+            )
+            parquet_keys = s3_hook.list_keys(bucket_name=BUCKET_NAME, prefix=prefix)
+            for key in parquet_keys:
+                if key.endswith(".parquet"):
+                    obj = s3_hook.get_key(key, BUCKET_NAME)
+                    manifest_entries["entries"].append(
+                        {
+                            "url": f"s3://{BUCKET_NAME}/{key}",
+                            "mandatory": True,
+                            "meta": {"content_length": obj.content_length},
+                        }
+                    )
+
+            current_dt += timedelta(hours=1)
+
+        if not manifest_entries["entries"]:
+            logger.warning("No parquet files found to create manifest.")
+            return
+
+        # Upload manifest to S3
+        manifest_filename = (
+            f"weather_night_backfill_data_load_{kst_time.strftime('%Y%m%d%H%M')}.json"
+        )
+        manifest_key = f"redshift-manifests/weather/{manifest_filename}"
+        manifest_content = json.dumps(manifest_entries, indent=2)
+
+        s3_hook.load_string(
+            string_data=manifest_content,
+            key=manifest_key,
+            bucket_name=BUCKET_NAME,
+            replace=True,
+        )
+
+        manifest_s3_path = f"s3://{BUCKET_NAME}/{manifest_key}"
+        logger.info(f"Manifest file uploaded to: {manifest_s3_path}")
+
+        # Execute Redshift COPY command using manifest
+        redshift = RedshiftSQLHook("redshift_conn_id")
+        target_table = "source.source_weather"
+        redshift_iam_role_arn = Variable.get("REDSHIFT_IAM_ROLE_ARN")
+
+        delete_start_dt = start_dt.format("YYYY-MM-DD HH:00:00")
+        delete_end_dt = end_dt.format("YYYY-MM-DD HH:00:00")
+
+        redshift.run("BEGIN;")
+        redshift.run(f"""
+            DELETE FROM {target_table}
+            WHERE observed_at BETWEEN '{delete_start_dt}' AND '{delete_end_dt}';
+        """)
+        logger.info(
+            f"Deleting existing data for range: {delete_start_dt} to {delete_end_dt}"
+        )
+
+        redshift.run(f"""
+            COPY {target_table} (
+                area_code, observed_at, area_name, temperature,
+                sensible_temperature, max_temperature, min_temperature,
+                humidity, wind_direction, wind_speed, precipitation,
+                precipitation_type, precipitation_message, sunrise, sunset,
+                uv_index_level, uv_index_desc, uv_message,
+                pm25_index, pm25_value, pm10_index, pm10_value,
+                air_quality_index, air_quality_value, air_quality_main, air_quality_message,
+                created_at
+            )
+            FROM '{manifest_s3_path}'
+            IAM_ROLE '{redshift_iam_role_arn}'
+            FORMAT AS PARQUET
+            MANIFEST;
+        """)
+        logger.info(f"Copying data to Redshift using manifest from: {manifest_s3_path}")
+        redshift.run("COMMIT;")
+
+    @task.bash
+    def run_dbt():
+        return f"dbt run --project-dir {DBT_PROJECT_DIR} --profiles-dir {DBT_PROFILES_DIR} --select fact_weather"
+
+    load = load_to_redshift()
+    dbt = run_dbt()
+    run_glue_job >> load >> dbt
+
+
+weather_data_backfill_night()

--- a/glue_jobs/weather_data_backfill_night.py
+++ b/glue_jobs/weather_data_backfill_night.py
@@ -1,0 +1,166 @@
+import sys
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+from pyspark.context import SparkContext
+from awsglue.context import GlueContext
+from awsglue.job import Job
+from awsglue.utils import getResolvedOptions
+from pyspark.sql import functions as F
+from pyspark.sql.types import IntegerType, FloatType
+from pyspark.sql.functions import (
+    col,
+    explode,
+    to_timestamp,
+    current_timestamp,
+    from_utc_timestamp,
+    year,
+    month,
+    dayofmonth,
+    hour,
+)
+
+# -- Constants
+KST = ZoneInfo("Asia/Seoul")
+BUCKET_NAME = "de6-team1-bucket"
+BASE_RAW_S3_PATH = f"s3://{BUCKET_NAME}/raw-json"
+OUTPUT_PATH = f"s3://{BUCKET_NAME}/processed-data/weather/night-backfill/"
+
+
+# -- Functions
+def parse_logical_date(logical_date_str):
+    return datetime.fromisoformat(logical_date_str).astimezone(KST)
+
+
+def generate_s3_paths(start_dt, end_dt):
+    # Generate S3 paths from the past 12 hours
+    current = start_dt
+    paths = []
+    while current < end_dt:
+        path_ymd = current.strftime("%Y%m%d")
+        path_h = current.strftime("%H")
+        paths.append(f"{BASE_RAW_S3_PATH}/{path_ymd}/{path_h}*.json")
+        current += timedelta(hours=1)
+    return paths
+
+
+def flatten_and_transform(df):
+    # Flatten nested WEATHER_STTS array
+    exploded_df = df.filter(
+        F.col("WEATHER_STTS").isNotNull() & (F.size("WEATHER_STTS") > 0)
+    ).select(
+        col("AREA_CD").alias("area_code"),
+        col("AREA_NM").alias("area_name"),
+        explode(col("WEATHER_STTS")).alias("weather_data"),
+    )
+
+    # Select and cast required columns
+    final_df = exploded_df.select(
+        col("area_code"),
+        col("area_name"),
+        col("weather_data.TEMP").cast(FloatType()).alias("temperature"),
+        col("weather_data.SENSIBLE_TEMP")
+        .cast(FloatType())
+        .alias("sensible_temperature"),
+        col("weather_data.MAX_TEMP").cast(FloatType()).alias("max_temperature"),
+        col("weather_data.MIN_TEMP").cast(FloatType()).alias("min_temperature"),
+        col("weather_data.HUMIDITY").cast(IntegerType()).alias("humidity"),
+        col("weather_data.WIND_DIRCT").alias("wind_direction"),
+        col("weather_data.WIND_SPD").cast(FloatType()).alias("wind_speed"),
+        col("weather_data.PRECIPITATION").alias("precipitation"),
+        col("weather_data.PRECPT_TYPE").alias("precipitation_type"),
+        col("weather_data.PCP_MSG").alias("precipitation_message"),
+        col("weather_data.SUNRISE").alias("sunrise"),
+        col("weather_data.SUNSET").alias("sunset"),
+        col("weather_data.UV_INDEX_LVL").cast(IntegerType()).alias("uv_index_level"),
+        col("weather_data.UV_INDEX").alias("uv_index_desc"),
+        col("weather_data.UV_MSG").alias("uv_message"),
+        col("weather_data.PM25_INDEX").alias("pm25_index"),
+        col("weather_data.PM25").cast(IntegerType()).alias("pm25_value"),
+        col("weather_data.PM10_INDEX").alias("pm10_index"),
+        col("weather_data.PM10").cast(IntegerType()).alias("pm10_value"),
+        col("weather_data.AIR_IDX").alias("air_quality_index"),
+        F.when(col("weather_data.AIR_IDX_MVL") == "점검중", None)
+        .otherwise(col("weather_data.AIR_IDX_MVL").cast(FloatType()))
+        .alias("air_quality_value"),
+        col("weather_data.AIR_IDX_MAIN").alias("air_quality_main"),
+        col("weather_data.AIR_MSG").alias("air_quality_message"),
+        to_timestamp(col("weather_data.WEATHER_TIME"), "yyyy-MM-dd HH:mm").alias(
+            "observed_at"
+        ),
+        from_utc_timestamp(current_timestamp(), "Asia/Seoul").alias("created_at"),
+    )
+
+    # Deduplicate by keeping max values per area and timestamp
+    grouping_columns = ["area_code", "observed_at"]
+    agg_exprs = [
+        F.max(col(c)).alias(c) for c in final_df.columns if c not in grouping_columns
+    ]
+    grouped_df = final_df.groupBy(grouping_columns).agg(*agg_exprs)
+
+    return (
+        grouped_df.withColumn("year", year(col("observed_at")))
+        .withColumn("month", month(col("observed_at")))
+        .withColumn("day", dayofmonth(col("observed_at")))
+        .withColumn("hour", hour(col("observed_at")))
+    )
+
+
+def main():
+    args = getResolvedOptions(sys.argv, ["JOB_NAME", "logical_date"])
+    logical_date = parse_logical_date(args["logical_date"])
+    start_dt = logical_date - timedelta(hours=12)
+    end_dt = logical_date
+    paths = generate_s3_paths(start_dt, end_dt)
+
+    # Initialize Spark and Glue contexts
+    sc = SparkContext()
+    glueContext = GlueContext(sc)
+    spark = glueContext.spark_session
+    job = Job(glueContext)
+    job.init(args["JOB_NAME"], args)
+
+    df = spark.read.json(paths)
+    transformed_df = flatten_and_transform(df)
+
+    # Reorder columns to match Redshift COPY and write to S3 in parquet format
+    transformed_df.select(
+        "area_code",
+        "observed_at",
+        "area_name",
+        "temperature",
+        "sensible_temperature",
+        "max_temperature",
+        "min_temperature",
+        "humidity",
+        "wind_direction",
+        "wind_speed",
+        "precipitation",
+        "precipitation_type",
+        "precipitation_message",
+        "sunrise",
+        "sunset",
+        "uv_index_level",
+        "uv_index_desc",
+        "uv_message",
+        "pm25_index",
+        "pm25_value",
+        "pm10_index",
+        "pm10_value",
+        "air_quality_index",
+        "air_quality_value",
+        "air_quality_main",
+        "air_quality_message",
+        "created_at",
+        "year",
+        "month",
+        "day",
+        "hour",
+    ).write.mode("overwrite").partitionBy("year", "month", "day", "hour").parquet(
+        OUTPUT_PATH
+    )
+
+    job.commit()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- EC2 서버는 **21시부터 다음날 09시까지 4차례 자동으로 종료되는 정책**이 있습니다.
  이 시간 동안 실시간 DAG이 실행되지 않아 **기상 데이터 누락**이 발생할 수 있습니다.
  누락된 **야간 시간대 기상 데이터를 백필**하기 위한 별도의 DAG이 필요했습니다.
  처리하지 못한 야간 데이터는 양이 주간에 처리되는 데이터 보다 훨씬 많고, 여러 시간대 데이터를 동시에 처리해야 하므로 **병렬 처리에 유리한 AWS Glue를 채택**하게 되었습니다.

### Key Changes (Screenshot, if any)
<img width="1232" height="446" alt="image" src="https://github.com/user-attachments/assets/bf799036-a6c7-4c10-8428-f5f56aa8ce22" />

- weather_data_backfill_night glue job 추가
- weather_data_backfill_night dag 추가
    - Glue Job 실행: S3 원본 데이터를 변환하여 Parquet 저장
    - manifest 파일을 생성하여 Redshift로 적재 (COPY)
    - dbt `fact_weather` 모델 실행으로 팩트 테이블 최신화

### To Reviewers

- Glue 스크립트 실행과 S3 → Redshift 로드 사이의 연결 흐름이 올바른지 검토 요청드립니다.
